### PR TITLE
fixed parsing of UniProt headers and added tests to catch errors

### DIFF
--- a/examples/database_generation/main.py
+++ b/examples/database_generation/main.py
@@ -36,3 +36,5 @@ assert sdf is not None
 
 print(sdf)
 print(sdf.columns)
+
+print("Number of binding sites in sample:", sdf["binding"].sum())

--- a/procaliper/_protein.py
+++ b/procaliper/_protein.py
@@ -71,7 +71,8 @@ class Protein:
 
     def _rectify_label(self, label: str) -> str:
         new_label = label.replace(" ", "_").lower()
-        new_label = new_label.replace("_site_sites", "_sites")
+        new_label = new_label.removesuffix("_site_sites")
+        new_label = new_label.removesuffix("_site")
         return new_label
 
     def _rectify_data_labels(self) -> None:

--- a/tests/test_protein_class.py
+++ b/tests/test_protein_class.py
@@ -88,6 +88,35 @@ def test_unravel():
     assert unravelled == expected
 
 
+def test_read_row_with_site_data():
+    TEST_HEADER = "Entry	Reviewed	Entry Name	Protein names	Gene Names	Organism	Length	Sequence	Active site	Binding site	DNA binding	Disulfide bond	Beta strand	Helix	Turn"
+    TEST_ROW = 'A0A0K2S4Q6	reviewed	CD3CH_HUMAN	Protein CD300H (CD300 antigen-like family member H)	CD300H	Homo sapiens (Human)	201	MTQRAGAAMLPSALLLLCVPGCLTVSGPSTVMGAVGESLSVQCRYEEKYKTFNKYWCRQPCLPIWHEMVETGGSEGVVRSDQVIITDHPGDLTFTVTLENLTADDAGKYRCGIATILQEDGLSGFLPDPFFQVQVLVSSASSTENSVKTPASPTRPSQCQGSLPSSTCFLLLPLLKVPLLLSILGAILWVNRPWRTPWTES				DISULFID 43..111; /evidence="ECO:0000255|PROSITE-ProRule:PRU00114"			'
+
+    row_dict = {k: v for k, v in zip(TEST_HEADER.split("\t"), TEST_ROW.split("\t"))}
+    protein = Protein.from_uniprot_row(row_dict)
+
+    assert protein.site_annotations is not None
+
+    dbonds = protein.site_annotations.disulfide_bond
+    assert dbonds is not None
+    assert all(dbonds[42:111])  # 43..111, one-indexed
+    assert not any(dbonds[:42]) and not any(dbonds[111:])
+
+
+def test_read_row_with_binding_site_data():
+    TEST_HEADER = "Entry	Reviewed	Entry Name	Protein names	Gene Names	Organism	Length	Sequence	Active site	Binding site	DNA binding	Disulfide bond	Beta strand	Helix	Turn"
+    TEST_ROW = 'A0A087X1C5	reviewed	CP2D7_HUMAN	Putative cytochrome P450 2D7 (EC 1.14.14.1)	CYP2D7	Homo sapiens (Human)	515	MGLEALVPLAMIVAIFLLLVDLMHRHQRWAARYPPGPLPLPGLGNLLHVDFQNTPYCFDQLRRRFGDVFSLQLAWTPVVVLNGLAAVREAMVTRGEDTADRPPAPIYQVLGFGPRSQGVILSRYGPAWREQRRFSVSTLRNLGLGKKSLEQWVTEEAACLCAAFADQAGRPFRPNGLLDKAVSNVIASLTCGRRFEYDDPRFLRLLDLAQEGLKEESGFLREVLNAVPVLPHIPALAGKVLRFQKAFLTQLDELLTEHRMTWDPAQPPRDLTEAFLAKKEKAKGSPESSFNDENLRIVVGNLFLAGMVTTSTTLAWGLLLMILHLDVQRGRRVSPGCPIVGTHVCPVRVQQEIDDVIGQVRRPEMGDQAHMPCTTAVIHEVQHFGDIVPLGVTHMTSRDIEVQGFRIPKGTTLITNLSSVLKDEAVWKKPFRFHPEHFLDAQGHFVKPEAFLPFSAGRRACLGEPLARMELFLFFTSLLQHFSFSVAAGQPRPSHSRVVSFLVTPSPYELCAVPR		BINDING 461; /ligand="heme"; /ligand_id="ChEBI:CHEBI:30413"; /ligand_part="Fe"; /ligand_part_id="ChEBI:CHEBI:18248"; /note="axial binding residue"; /evidence="ECO:0000250|UniProtKB:P10635"					'
+
+    row_dict = {k: v for k, v in zip(TEST_HEADER.split("\t"), TEST_ROW.split("\t"))}
+    protein = Protein.from_uniprot_row(row_dict)
+
+    assert protein.site_annotations is not None
+
+    bsite = protein.site_annotations.binding
+    assert bsite is not None
+    assert bsite[460]
+
+
 def test_fetch_pdb():
     TEST_HEADER = "Entry	Reviewed	Entry Name	Protein names	Gene Names	Organism	Length	Sequence	Active site	Binding site	DNA binding	Disulfide bond	Beta strand	Helix	Turn"
     TEST_ROW = "A0A0B4J2F0	reviewed	PIOS1_HUMAN	Protein PIGBOS1 (PIGB opposite strand protein 1)	PIGBOS1	Homo sapiens (Human)	54	MFRRLTFAQLLFATVLGIAGGVYIFQPVFEQYAKDQKELKEKMQLVQESEEKKS							"


### PR DESCRIPTION
The code for site annotations (#23) was mistakenly written expecting headers for binding/active data to be "Binding" and "Active", not "Binding site" and "Active site". This PR fixes this and introduces tests that would have caught this bug.